### PR TITLE
Add extended ignore for apache & nginx conf's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,10 @@ vendor
 .vagrant
 
 
-# apache conf
-Apache-2.4_vhost.conf
-Apache-2.4-x64_vhost.conf
+# apache & nginx conf
+*vhost.conf
+*vhosta.conf
+*vhostn.conf
 
 
 # опасные файлы технических скриптов


### PR DESCRIPTION
Ignore names like:
```
Apache-2.4_vhost.conf
Apache-2.4-x64_vhost.conf
Apache-PHP-7-x64+Nginx-1.12_vhosta.conf
Apache-PHP-7-x64+Nginx-1.12_vhostn.conf
```